### PR TITLE
T32033 zim file search

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,13 +6,14 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-nodeenv = "==1.3.3"
-ipdb = "==0.13.2"
+beautifulsoup4 = "==4.9.3"
+bumpversion = "*"
 flake8 = "==3.8.3"
+ipdb = "==0.13.2"
+libzim = "==0.0.3.post0"
+nodeenv = "==1.3.3"
 pre-commit = "==1.15.1"
 twine = "*"
-bumpversion = "*"
-libzim = "==0.0.3.post0"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "689f596b9694fc75be3a6b670a9d6278adb32037221fa566e1a99b5984c005d2"
+            "sha256": "458fccd66be49e2e0363355316e300a9e1c3629dbf968b8fc8728820ad500cef"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -37,6 +37,15 @@
                 "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"
             ],
             "version": "==0.2.0"
+        },
+        "beautifulsoup4": {
+            "hashes": [
+                "sha256:4c98143716ef1cb40bf7f39a8e3eec8f8b009509e74904ba3a7b315431577e35",
+                "sha256:84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25",
+                "sha256:fff47e031e34ec82bf17e00da8f592fe7de69aeea38be00523c04623c04fb666"
+            ],
+            "index": "pypi",
+            "version": "==4.9.3"
         },
         "bleach": {
             "hashes": [
@@ -205,11 +214,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:3a74cf41f1a0bde21e2f196a1727a608629339d9897226bad07b22e0bbde6faa",
-                "sha256:7d4a73d58869a484d4ba8892793c80e30aa699e77707f26c1049486ef9be415f"
+                "sha256:18d0c531ee3dbc112fa6181f34faa179de3f57ea57ae2899754f16a7e0ff6421",
+                "sha256:5b41f71471bc738e7b586308c3fca172f78940195cb3bf6734c1e66fdac49306"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==2.2.8"
+            "version": "==2.2.10"
         },
         "idna": {
             "hashes": [
@@ -221,11 +230,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:960d52ba7c21377c990412aca380bf3642d734c2eaab78a2c39319f67c6a5786",
-                "sha256:e592faad8de1bda9fe920cf41e15261e7131bcf266c30306eec00e8e225c1dd5"
+                "sha256:833b26fb89d5de469b24a390e9df088d4e52e4ba33b01dc5e0e4f41b81a16c00",
+                "sha256:b142cc1dd1342f31ff04bb7d022492b09920cb64fed867cd3ea6f80fe3ebd139"
             ],
-            "markers": "python_version < '3.8' and python_version < '3.8'",
-            "version": "==4.4.0"
+            "markers": "python_version < '3.8'",
+            "version": "==4.5.0"
         },
         "ipdb": {
             "hashes": [
@@ -406,7 +415,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pyyaml": {
@@ -486,15 +495,23 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "soupsieve": {
+            "hashes": [
+                "sha256:052774848f448cf19c7e959adf5566904d525f33a3f8b6ba6f6f8f26ec7de0cc",
+                "sha256:c2c1c2d44f158cdbddab7824a9af8c4f83c76b1e23e049479aa432feb6c4c23b"
+            ],
+            "markers": "python_version >= '3.0'",
+            "version": "==2.2.1"
         },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "tqdm": {

--- a/kolibri_zim_plugin/assets/src/api-resources/zimSearchResource.js
+++ b/kolibri_zim_plugin/assets/src/api-resources/zimSearchResource.js
@@ -3,12 +3,12 @@ import urls from 'kolibri.urls';
 
 export default new Resource({
   name: 'zim',
-  search(zim_filename, { query, max_results, suggest }) {
+  search(zim_filename, { query, start, max_results, suggest }) {
     const url = urls.zim_search(zim_filename);
     return this.client({
       url,
       method: 'get',
-      params: { query, max_results, suggest },
+      params: { query, start, max_results, suggest },
     });
   },
 });

--- a/kolibri_zim_plugin/assets/src/api-resources/zimSearchResource.js
+++ b/kolibri_zim_plugin/assets/src/api-resources/zimSearchResource.js
@@ -1,0 +1,14 @@
+import { Resource } from 'kolibri.lib.apiResource';
+import urls from 'kolibri.urls';
+
+export default new Resource({
+  name: 'zim',
+  search(zim_filename, { query, max_results, suggest }) {
+    const url = urls.zim_search(zim_filename);
+    return this.client({
+      url,
+      method: 'get',
+      params: { query, max_results, suggest },
+    });
+  },
+});

--- a/kolibri_zim_plugin/assets/src/views/ZimBreadcrumbsMenu.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimBreadcrumbsMenu.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <ol class="breadcrumbs-list">
+  <transition-group class="breadcrumbs-list" name="breadcrumbs-fade" mode="out-in" tag="ol">
     <template v-for="(breadcrumb, index) in visibleBreadcrumbs">
       <li
         :ref="`breadcrumb${index}`"
@@ -18,7 +18,7 @@
         />
       </li>
     </template>
-  </ol>
+  </transition-group>
 
 </template>
 
@@ -75,6 +75,16 @@
   .breadcrumb-button {
     text-overflow: ellipsis;
     text-transform: none;
+  }
+
+  .breadcrumbs-fade-enter-active,
+  .breadcrumbs-fade-leave-active {
+    transition: opacity 0.5s;
+  }
+
+  .breadcrumbs-fade-enter,
+  .breadcrumbs-fade-leave-to {
+    opacity: 0;
   }
 
 </style>

--- a/kolibri_zim_plugin/assets/src/views/ZimBreadcrumbsMenu.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimBreadcrumbsMenu.vue
@@ -1,0 +1,80 @@
+<template>
+
+  <ol class="breadcrumbs-list">
+    <template v-for="(breadcrumb, index) in visibleBreadcrumbs">
+      <li
+        :ref="`breadcrumb${index}`"
+        :key="index"
+        class="breadcrumb-item"
+      >
+        <KButton
+          class="breadcrumb-button"
+          :primary="false"
+          appearance="flat-button"
+          :text="breadcrumb.title"
+          :disabled="!breadcrumbIsEnabled(breadcrumb)"
+          tabindex="-1"
+          @click="$emit('activate', breadcrumb)"
+        />
+      </li>
+    </template>
+  </ol>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'ZimBreadcrumbsMenu',
+    components: {},
+    props: {
+      breadcrumbs: {
+        type: Array,
+      },
+      currentUrl: {
+        type: String,
+      },
+    },
+    computed: {
+      visibleBreadcrumbs() {
+        return this.breadcrumbs.slice(-4);
+      },
+    },
+    methods: {
+      breadcrumbIsEnabled(breadcrumb) {
+        if (breadcrumb.href === undefined) {
+          return false;
+        } else {
+          return breadcrumb.href !== this.currentUrl;
+        }
+      },
+    },
+    $trs: {},
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  ol {
+    display: inline-block;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  li {
+    display: inline-block;
+    max-width: 10rem;
+  }
+
+  .breadcrumb-button {
+    text-overflow: ellipsis;
+    text-transform: none;
+  }
+
+</style>

--- a/kolibri_zim_plugin/assets/src/views/ZimContent.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimContent.vue
@@ -1,0 +1,90 @@
+<template>
+
+  <iframe
+    ref="iframe"
+    class="iframe"
+    sandbox="allow-scripts allow-same-origin"
+    frameBorder="0"
+    :style="{ backgroundColor: this.$themePalette.white }"
+    :src="indexUrl"
+    @load="onIframeLoad"
+  ></iframe>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'ZimContent',
+    components: {},
+    props: {
+      indexUrl: {
+        type: String,
+      },
+    },
+    computed: {},
+    methods: {
+      /**
+       * @public
+       */
+      navigate(url) {
+        this.$refs.iframe.contentWindow.location = url;
+      },
+      onIframeLoad() {
+        try {
+          this.$refs.iframe.contentWindow.removeEventListener('unload', this.onIframeUnload);
+          this.$refs.iframe.contentWindow.addEventListener('unload', this.onIframeUnload);
+        } catch (DOMException) {
+          // pass
+        }
+        this.onIframeLocationChanged();
+      },
+      onIframeUnload() {
+        setTimeout(this.onIframeLocationChanged, 0);
+      },
+      onIframeLocationChanged() {
+        // FIXME: Building the breadcrumb trail here involves reading from
+        //        iframe.contentWindow.location, which is not possible with
+        //        cross-origin iframes. This will need to be rewritten when
+        //        the zim backend is moved to a different server.
+
+        let href, title, isLoading, isExternal;
+        const contentDocument = this.$refs.iframe.contentDocument;
+        const contentWindow = this.$refs.iframe.contentWindow;
+
+        try {
+          href = contentWindow.location.href;
+        } catch (DOMException) {
+          href = undefined;
+        }
+
+        if (contentDocument && contentDocument.readyState == 'loading') {
+          title = '…';
+          isLoading = true;
+        } else if (contentDocument) {
+          title = contentDocument.title;
+        } else {
+          title = '…';
+          isExternal = true;
+        }
+
+        this.$emit('onnavigate', { href, title, isLoading, isExternal });
+      },
+    },
+    $trs: {},
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  .iframe {
+    width: 100%;
+    height: 100%;
+  }
+
+</style>

--- a/kolibri_zim_plugin/assets/src/views/ZimContentView.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimContentView.vue
@@ -15,21 +15,33 @@
 
 <script>
 
+  import urls from 'kolibri.urls';
+
   export default {
-    name: 'ZimContent',
+    name: 'ZimContentView',
     components: {},
     props: {
-      indexUrl: {
+      zimFilename: {
         type: String,
       },
     },
-    computed: {},
+    computed: {
+      indexUrl() {
+        return urls.zim_index(this.zimFilename);
+      },
+    },
     methods: {
       /**
        * @public
        */
-      navigate(url) {
+      navigateToUrl(url) {
         this.$refs.iframe.contentWindow.location = url;
+      },
+      /**
+       * @public
+       */
+      navigateToArticle(path) {
+        this.$refs.iframe.contentWindow.location = this.articleUrl(path);
       },
       onIframeLoad() {
         try {
@@ -70,6 +82,9 @@
         }
 
         this.$emit('onnavigate', { href, title, isLoading, isExternal });
+      },
+      articleUrl(path) {
+        return urls.zim_article(this.zimFilename, path);
       },
     },
     $trs: {},

--- a/kolibri_zim_plugin/assets/src/views/ZimRendererIndex.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimRendererIndex.vue
@@ -40,14 +40,21 @@
       </KButton>
     </div>
     <div class="main-container" :style="mainContainerStyle">
-      <ZimSearchView
-        ref="zimSearchView"
+      <div
+        ref="zimSearchOverlay"
+        class="zim-search-overlay"
         :hidden="!isSearching"
-        :zimFilename="zimFilename"
-      />
+        @click="onZimSearchOverlayClick($event)"
+      >
+        <ZimSearchView
+          ref="zimSearchView"
+          :zimFilename="zimFilename"
+          @activate="onZimSearchViewActivate"
+          @cancel="onZimSearchViewCancel"
+        />
+      </div>
       <ZimContentView
         ref="zimContentView"
-        :hidden="isSearching"
         :zimFilename="zimFilename"
         @onnavigate="onZimContentViewNavigate"
       />
@@ -60,7 +67,6 @@
 <script>
 
   import CoreFullscreen from 'kolibri.coreVue.components.CoreFullscreen';
-  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
 
   import ZimBreadcrumbsMenu from './ZimBreadcrumbsMenu';
   import ZimContentView from './ZimContentView';
@@ -184,6 +190,21 @@
           this.$refs.zimContentView.navigateToUrl(breadcrumb.href);
         }
       },
+      onZimSearchViewActivate({ path }) {
+        this.isSearching = false;
+        // Assume that the first item in zimNavigationHistory is the home
+        // article, which we want to keep, and remove everything else.
+        this.zimNavigationHistory.splice(1);
+        this.$refs.zimContentView.navigateToArticle(path);
+      },
+      onZimSearchViewCancel() {
+        this.isSearching = false;
+      },
+      onZimSearchOverlayClick(event) {
+        if (event.target === this.$refs.zimSearchOverlay) {
+          this.isSearching = false;
+        }
+      },
       onZimContentViewNavigate({ href, title }) {
         this.currentUrl = href;
 
@@ -192,7 +213,7 @@
         );
 
         if (existingIndex >= 0) {
-          this.zimNavigationHistory = this.zimNavigationHistory.slice(0, existingIndex);
+          this.zimNavigationHistory.splice(existingIndex);
         }
 
         if (this.zimNavigationHistory.length == 0) {
@@ -219,6 +240,7 @@
 <style lang="scss" scoped>
 
   @import '~kolibri-design-system/lib/styles/definitions';
+  @import '~kolibri-design-system/lib/keen/styles/md-colors';
 
   .zim-renderer {
     position: relative;
@@ -241,10 +263,29 @@
   .main-container {
     @extend %momentum-scroll;
 
+    position: relative;
     width: 100%;
     padding-top: 0.25rem;
     overflow: hidden;
     background-color: #ffffff;
+  }
+
+  .zim-search-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(255, 255, 255, 0.8);
+
+    .zim-search {
+      position: relative;
+      width: 100%;
+      max-height: 100%;
+      overflow: auto;
+      background-color: $md-grey-200;
+      border-bottom: solid 2px $md-grey-400;
+    }
   }
 
 </style>

--- a/kolibri_zim_plugin/assets/src/views/ZimRendererIndex.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimRendererIndex.vue
@@ -39,6 +39,10 @@
         {{ fullscreenText }}
       </KButton>
     </div>
+    <div class="search" :style="searchStyle">
+      <p>Search box and search results go here</p>
+      <ZimSearchForm ref="searchForm" />
+    </div>
     <div class="zim-content-container" :style="zimContentContainerStyle">
       <ZimContent
         ref="zimContent"
@@ -59,6 +63,7 @@
 
   import ZimBreadcrumbsMenu from './ZimBreadcrumbsMenu';
   import ZimContent from './ZimContent';
+  import ZimSearchForm from './ZimSearchForm';
 
   const defaultContentHeight = '500px';
   const defaultFullscreenHeaderHeight = '37px';
@@ -76,6 +81,7 @@
     data() {
       return {
         isInFullscreen: false,
+        isSearching: false,
         currentUrl: undefined,
         zimNavigationHistory: new Array(),
         fullscreenHeaderHeight: defaultFullscreenHeaderHeight,
@@ -109,7 +115,14 @@
           return { backgroundColor: this.$themePalette.grey.v_200 };
         }
       },
-      iframeContainerStyle() {
+      searchStyle() {
+        if (this.isSearching) {
+          return { display: 'block' };
+        } else {
+          return { display: 'none' };
+        }
+      },
+      zimContentContainerStyle() {
         if (this.isSearching) {
           return { display: 'none' };
         } else if (this.isInFullscreen) {
@@ -169,9 +182,6 @@
           this.recordProgress();
         }, 15000);
       },
-      onNavSearchClick() {
-        alert('TODO: Search');
-      },
       onZimContentNavigate({ href, title }) {
         this.currentUrl = href;
 
@@ -191,7 +201,14 @@
 
         this.zimNavigationHistory.push({ title, href });
       },
+      onNavSearchClick() {
+        this.isSearching = true;
+        setTimeout(() => {
+          if (this.$refs.searchForm) this.$refs.searchForm.focus();
+        }, 100);
+      },
       onNavBreadcrumbClick(breadcrumb) {
+        this.isSearching = false;
         if (breadcrumb.href) {
           this.$refs.zimContent.navigate(breadcrumb.href);
         }

--- a/kolibri_zim_plugin/assets/src/views/ZimRendererIndex.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimRendererIndex.vue
@@ -284,7 +284,7 @@
       max-height: 100%;
       overflow: auto;
       background-color: $md-grey-200;
-      border-bottom: solid 2px $md-grey-400;
+      border-bottom: 2px solid $md-grey-400;
     }
   }
 

--- a/kolibri_zim_plugin/assets/src/views/ZimSearchForm.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimSearchForm.vue
@@ -21,7 +21,7 @@
         name="search-input"
         class="search-input"
         dir="auto"
-        :placeholder="coreString('searchLabel')"
+        :placeholder="$tr('searchPlaceholder')"
       >
       <div class="search-buttons-wrapper">
         <KIconButton
@@ -125,6 +125,7 @@
     $trs: {
       clearButtonLabel: 'Clear',
       startSearchButtonLabel: 'Start search',
+      searchPlaceholder: 'Search for an article',
     },
   };
 

--- a/kolibri_zim_plugin/assets/src/views/ZimSearchForm.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimSearchForm.vue
@@ -2,8 +2,8 @@
 
   <form
     class="search-box"
-    @submit.prevent="updateSearchQuery"
-    @keydown.esc.prevent="handleEscKey"
+    @submit.prevent="onSubmit"
+    @keydown.esc.prevent="onEscKeyDown"
   >
     <div
       class="search-box-row"
@@ -31,7 +31,7 @@
           class="search-clear-button"
           :class="searchInputValue === '' ? '' : 'search-clear-button-visible'"
           :ariaLabel="$tr('clearButtonLabel')"
-          @click="handleClickClear"
+          @click="onClearButtonClick"
         />
         <div
           class="search-submit-button-wrapper"
@@ -80,13 +80,14 @@
     },
     data() {
       return {
-        searchInputValue: '', // TODO: !!!!!!!!!!
+        searchInputValue: '',
+        lastSubmitValue: '',
       };
     },
     computed: {
       searchBarDisabled() {
         // Disable the search bar if it has been cleared or has not been changed
-        return this.searchInputValue === '' || this.searchInputValue === this.searchTerm;
+        return this.searchInputValue === this.lastSubmitValue;
       },
     },
     mounted() {},
@@ -98,28 +99,29 @@
       focus() {
         this.$refs.searchInput.focus();
       },
-      clearInput() {
-        this.searchInputValue = '';
-      },
-      handleEscKey() {
+      onEscKeyDown() {
         if (this.searchInputValue === '') {
-          this.$emit('closeDropdownSearchBox');
+          this.$emit('cancel');
         } else {
           this.clearInput();
         }
       },
-      handleClickClear() {
+      onClearButtonClick() {
         this.clearInput();
         this.$refs.searchInput.focus();
       },
-      updateSearchQuery() {
-        // const query = {
-        //   searchTerm: this.searchInputValue || this.$route.query.searchTerm,
-        // };
-        // if (this.filters) {
-        //   query.kind = this.$refs.contentKindFilter.selection.value;
-        //   query.channel_id = this.$refs.channelFilter.selection.value;
-        // }
+      onSubmit() {
+        this.lastSubmitValue = this.searchInputValue;
+        if (this.searchInputValue) {
+          this.$emit('submit', this.searchInputValue);
+        } else {
+          this.$emit('reset');
+        }
+      },
+      clearInput() {
+        this.searchInputValue = '';
+        this.lastSubmitValue = '';
+        this.$emit('reset');
       },
     },
     $trs: {
@@ -135,10 +137,6 @@
 <style lang="scss" scoped>
 
   @import '~kolibri-design-system/lib/styles/definitions';
-
-  .search-box {
-    margin-right: 8px;
-  }
 
   .search-box-within-action-bar {
     width: 235px;

--- a/kolibri_zim_plugin/assets/src/views/ZimSearchForm.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimSearchForm.vue
@@ -1,0 +1,202 @@
+<template>
+
+  <form
+    class="search-box"
+    @submit.prevent="updateSearchQuery"
+    @keydown.esc.prevent="handleEscKey"
+  >
+    <div
+      class="search-box-row"
+      :style="{
+        backgroundColor: $themeTokens.surface,
+        borderColor: $themePalette.grey.v_300,
+        fontSize: '16px',
+      }"
+    >
+      <label class="visuallyhidden" for="search-input">{{ coreString('searchLabel') }}</label>
+      <input
+        ref="searchInput"
+        v-model.trim="searchInputValue"
+        type="search"
+        name="search-input"
+        class="search-input"
+        dir="auto"
+        :placeholder="coreString('searchLabel')"
+      >
+      <div class="search-buttons-wrapper">
+        <KIconButton
+          icon="clear"
+          :color="$themeTokens.text"
+          size="small"
+          class="search-clear-button"
+          :class="searchInputValue === '' ? '' : 'search-clear-button-visible'"
+          :ariaLabel="$tr('clearButtonLabel')"
+          @click="handleClickClear"
+        />
+        <div
+          class="search-submit-button-wrapper"
+          :style="{ backgroundColor: $themeTokens.primaryDark }"
+        >
+          <KIconButton
+            :icon="icon"
+            color="white"
+            class="search-submit-button"
+            :disabled="searchBarDisabled"
+            :class="{ 'rtl-icon': icon === 'forward' && isRtl }"
+            :style="{ fill: $themeTokens.textInverted }"
+            :ariaLabel="$tr('startSearchButtonLabel')"
+            type="submit"
+          />
+        </div>
+      </div>
+    </div>
+  </form>
+
+</template>
+
+
+<script>
+
+  /*
+   * From SearchBox.vue in Kolibri:
+   * <https://github.com/learningequality/kolibri/blob/develop/kolibri/plugins/learn/assets/src/views/SearchBox.vue>
+   * We need our own version because the upstream one modifies this.$router.
+   */
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+
+  export default {
+    name: 'ZimSearchForm',
+    components: {},
+    mixins: [commonCoreStrings],
+    props: {
+      icon: {
+        type: String,
+        default: 'search',
+        validator(val) {
+          return ['search', 'forward'].includes(val);
+        },
+      },
+    },
+    data() {
+      return {
+        searchInputValue: '', // TODO: !!!!!!!!!!
+      };
+    },
+    computed: {
+      searchBarDisabled() {
+        // Disable the search bar if it has been cleared or has not been changed
+        return this.searchInputValue === '' || this.searchInputValue === this.searchTerm;
+      },
+    },
+    mounted() {},
+    beforeDestroy() {},
+    methods: {
+      /**
+       * @public
+       */
+      focus() {
+        this.$refs.searchInput.focus();
+      },
+      clearInput() {
+        this.searchInputValue = '';
+      },
+      handleEscKey() {
+        if (this.searchInputValue === '') {
+          this.$emit('closeDropdownSearchBox');
+        } else {
+          this.clearInput();
+        }
+      },
+      handleClickClear() {
+        this.clearInput();
+        this.$refs.searchInput.focus();
+      },
+      updateSearchQuery() {
+        // const query = {
+        //   searchTerm: this.searchInputValue || this.$route.query.searchTerm,
+        // };
+        // if (this.filters) {
+        //   query.kind = this.$refs.contentKindFilter.selection.value;
+        //   query.channel_id = this.$refs.channelFilter.selection.value;
+        // }
+      },
+    },
+    $trs: {
+      clearButtonLabel: 'Clear',
+      startSearchButtonLabel: 'Start search',
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  .search-box {
+    margin-right: 8px;
+  }
+
+  .search-box-within-action-bar {
+    width: 235px;
+  }
+
+  .search-box-row {
+    display: table;
+    width: 100%;
+    max-width: 450px;
+    margin: 0 auto;
+    overflow: hidden;
+    border: solid 1px;
+    border-radius: $radius;
+  }
+
+  .search-input {
+    display: table-cell;
+    width: 100%;
+    height: 36px;
+    padding: 0;
+    padding-left: 8px;
+    margin: 0;
+    vertical-align: middle;
+    border: 0;
+
+    // removes the IE clear button
+    &::-ms-clear {
+      display: none;
+    }
+  }
+
+  .search-buttons-wrapper {
+    display: table-cell;
+    width: 80px;
+    height: 36px;
+    text-align: right;
+    vertical-align: middle;
+  }
+
+  .search-clear-button {
+    width: 24px;
+    height: 24px;
+    margin-right: 6px;
+    vertical-align: middle;
+    visibility: hidden;
+  }
+
+  .search-clear-button-visible {
+    visibility: visible;
+  }
+
+  .search-submit-button {
+    width: 36px;
+    height: 36px;
+  }
+
+  .search-submit-button-wrapper {
+    display: inline-block;
+    vertical-align: middle;
+  }
+
+</style>

--- a/kolibri_zim_plugin/assets/src/views/ZimSearchView.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimSearchView.vue
@@ -10,6 +10,36 @@
     <div v-if="isSearchWaiting" class="zim-search-loader">
       <KLinearLoader />
     </div>
+    <template v-if="searchResults.error">
+      <h2>There was an error searching for '{{ searchResults.query }}'</h2>
+      <TechnicalTextBlock :text="String(searchResults.error)" />
+    </template>
+    <template v-else-if="searchResults.success && searchResults.count > 0">
+      <h2>
+        {{ $tr(
+          'searchResultsMsg', { query: searchResults.query, count: searchResults.count }
+        ) }}
+      </h2>
+      <ol class="search-results-list">
+        <template v-for="(article, index) in searchResults.articles">
+          <li
+            :ref="`article${index}`"
+            :key="index"
+            class="search-result-item"
+          >
+            <KButton
+              appearance="basic-link"
+              :text="article.title"
+              :href="articleUrl(article.path)"
+              @click.prevent="$emit('activate', article)"
+            />
+          </li>
+        </template>
+      </ol>
+    </template>
+    <template v-else-if="searchResults.success && searchResults.count === 0">
+      <h2>{{ $tr('noSearchResultsMsg', { query: searchResults.query }) }}</h2>
+    </template>
   </div>
 
 </template>
@@ -18,6 +48,7 @@
 <script>
 
   import urls from 'kolibri.urls';
+  import TechnicalTextBlock from 'kolibri.coreVue.components.TechnicalTextBlock';
 
   import ZimSearchResource from '../api-resources/zimSearchResource';
   import ZimSearchForm from './ZimSearchForm';
@@ -26,6 +57,7 @@
     name: 'ZimSearchView',
     components: {
       ZimSearchForm,
+      TechnicalTextBlock,
     },
     props: {
       zimFilename: {
@@ -73,6 +105,11 @@
         return urls.zim_article(this.zimFilename, path);
       },
     },
+    $trs: {
+      searchResultsMsg:
+        "{count, plural, one {{count} result} other {Top {count} results}} for '{query}'",
+      noSearchResultsMsg: "No results for '{query}'",
+    },
   };
 
 </script>
@@ -81,12 +118,40 @@
 <style lang="scss" scoped>
 
   @import '~kolibri-design-system/lib/styles/definitions';
+  @import '~kolibri-design-system/lib/buttons-and-links/buttons';
 
   .zim-search {
-    width: 100%;
-    height: 100%;
-    overflow: auto;
     padding: 16px;
+  }
+
+  .zim-search-loader {
+    position: absolute;
+    right: 0;
+    left: 0;
+
+    .ui-progress-linear {
+      position: relative;
+      max-width: 450px;
+      margin: 0 auto;
+    }
+  }
+
+  ol {
+    display: block;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
+
+  li {
+    display: block;
+    margin: 0.5rem 0;
+
+    &::before {
+      display: inline-block;
+      margin: 0 6px 0 2px;
+      content: '\203A';
+    }
   }
 
 </style>

--- a/kolibri_zim_plugin/assets/src/views/ZimSearchView.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimSearchView.vue
@@ -7,7 +7,7 @@
       @reset="onSearchFormReset"
       @cancel="$emit('cancel')"
     />
-    <div v-if="isSearchWaiting" class="zim-search-loader">
+    <div v-if="isSearchWaiting > 0" class="zim-search-loader">
       <KLinearLoader />
     </div>
     <template v-if="searchResults.error">
@@ -17,7 +17,10 @@
     <template v-else-if="searchResults.success && searchResults.count > 0">
       <h2>
         {{ $tr(
-          'searchResultsMsg', { query: searchResults.query, count: searchResults.articles.length }
+          'searchResultsMsg', {
+            query: searchResults.query,
+            count: $formatNumber(searchResults.articles.length)
+          }
         ) }}
       </h2>
       <ol class="search-results-list">
@@ -36,6 +39,27 @@
           </li>
         </template>
       </ol>
+      <template v-if="searchHasMore">
+        <div class="search-footer">
+          <p>
+            {{ $tr(
+              'moreResultsMsg', {
+                count: $formatNumber(remainingResults)
+              }
+            ) }}
+          </p>
+          <div class="search-more">
+            <KButton
+              appearance="raised-button"
+              class="search-more-button"
+              :disabled="isSearchWaiting > 0 || isSearchMoreWaiting > 0"
+              :text="$tr('loadMoreButtonLabel')"
+              @click.prevent="onSearchMoreClick"
+            />
+            <KCircularLoader v-if="isSearchMoreWaiting > 0" />
+          </div>
+        </div>
+      </template>
     </template>
     <template v-else-if="searchResults.success && searchResults.count === 0">
       <h2>{{ $tr('noSearchResultsMsg', { query: searchResults.query }) }}</h2>
@@ -67,10 +91,22 @@
     data() {
       return {
         isSearchWaiting: 0,
+        isSearchMoreWaiting: 0,
         searchResults: {},
       };
     },
-    computed: {},
+    computed: {
+      searchHasMore() {
+        return this.searchResults.next;
+      },
+      remainingResults() {
+        if (this.searchResults.next) {
+          return this.searchResults.count - this.searchResults.next;
+        } else {
+          return 0;
+        }
+      },
+    },
     methods: {
       /**
        * @public
@@ -78,27 +114,57 @@
       focus() {
         this.$refs.searchForm.focus();
       },
-      onSearchFormSubmit(query) {
-        this.startSearch(query);
-      },
       onSearchFormReset() {
         this.searchResults = {};
       },
-      startSearch(query) {
+      onSearchFormSubmit(query) {
         this.isSearchWaiting += 1;
+        this.startSearch(query).finally(() => {
+          this.isSearchWaiting -= 1;
+        });
+      },
+      onSearchMoreClick() {
+        this.isSearchMoreWaiting += 1;
+        this.startSearch(this.searchResults.query, this.searchResults.next).finally(() => {
+          this.isSearchMoreWaiting -= 1;
+        });
+      },
+      startSearch(query, start = 0) {
+        const max_results = 10;
+        const snippet_length = 140;
 
-        const max_results = 100;
-
-        ZimSearchResource.search(this.zimFilename, { query, max_results })
+        return ZimSearchResource.search(this.zimFilename, {
+          query,
+          start,
+          max_results,
+          snippet_length,
+        })
           .then(result => {
             const { articles, count } = result.data;
-            this.searchResults = { query, articles, count, success: true };
+            const end = start + articles.length;
+            const next = end < count ? end : null;
+
+            if (query === this.searchResults.query && start === this.searchResults.next) {
+              // Add to the existing results
+              this.searchResults = {
+                query,
+                articles: this.searchResults.articles.concat(articles),
+                count,
+                next,
+                success: true,
+              };
+            } else {
+              this.searchResults = {
+                query,
+                articles,
+                count,
+                next,
+                success: true,
+              };
+            }
           })
           .catch(error => {
             this.searchResults = { query, error };
-          })
-          .finally(() => {
-            this.isSearchWaiting -= 1;
           });
       },
       articleUrl(path) {
@@ -109,6 +175,8 @@
       searchResultsMsg:
         "{count, plural, one {{count} result} other {Top {count} results}} for '{query}'",
       noSearchResultsMsg: "No results for '{query}'",
+      moreResultsMsg: '{count, plural, one {{count} more result} other {{count} more results}}',
+      loadMoreButtonLabel: 'Load more',
     },
   };
 
@@ -117,8 +185,9 @@
 
 <style lang="scss" scoped>
 
-  @import '~kolibri-design-system/lib/styles/definitions';
   @import '~kolibri-design-system/lib/buttons-and-links/buttons';
+  @import '~kolibri-design-system/lib/keen/styles/md-colors';
+  @import '~kolibri-design-system/lib/styles/definitions';
 
   .zim-search {
     padding: 16px;
@@ -145,12 +214,39 @@
 
   li {
     display: block;
-    margin: 0.5rem 0;
+    margin: 1rem 0;
+    border-bottom: 1px solid $md-grey-400;
 
-    &::before {
+    &:last-child {
+      border-bottom-style: none;
+    }
+
+    .link {
+      display: block;
+      font-weight: bold;
+    }
+
+    p {
+      margin: 0.5rem 0 1rem;
+      font-size: 0.9375rem;
+    }
+  }
+
+  .search-footer {
+    margin: 1rem 0;
+    text-align: center;
+    border-top: 1px solid $md-grey-400;
+
+    p {
+      margin-bottom: 0.5rem;
+    }
+  }
+
+  .search-more {
+    .ui-progress-circular {
+      position: absolute;
       display: inline-block;
-      margin: 0 6px 0 2px;
-      content: '\203A';
+      margin-left: 16px;
     }
   }
 

--- a/kolibri_zim_plugin/assets/src/views/ZimSearchView.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimSearchView.vue
@@ -17,7 +17,7 @@
     <template v-else-if="searchResults.success && searchResults.count > 0">
       <h2>
         {{ $tr(
-          'searchResultsMsg', { query: searchResults.query, count: searchResults.count }
+          'searchResultsMsg', { query: searchResults.query, count: searchResults.articles.length }
         ) }}
       </h2>
       <ol class="search-results-list">

--- a/kolibri_zim_plugin/assets/src/views/ZimSearchView.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimSearchView.vue
@@ -36,6 +36,7 @@
               :href="articleUrl(article.path)"
               @click.prevent="$emit('activate', article)"
             />
+            <p>{{ article.snippet }}&nbsp;&hellip;</p>
           </li>
         </template>
       </ol>

--- a/kolibri_zim_plugin/assets/src/views/ZimSearchView.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimSearchView.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="zim-search">
+    <ZimSearchForm ref="searchForm" />
+  </div>
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import urls from 'kolibri.urls';
+
+  import ZimSearchForm from './ZimSearchForm';
+
+  export default {
+    name: 'ZimRendererIndex',
+    components: {
+      ZimSearchForm,
+    },
+    props: {
+      zimFilename: {
+        type: String,
+      },
+    },
+    data() {
+      return {};
+    },
+    computed: {
+      searchText() {
+        return this.$tr('search');
+      },
+    },
+    methods: {
+      /**
+       * @public
+       */
+      focus() {
+        this.$refs.searchForm.focus();
+      },
+      articleUrl(path) {
+        return urls.zim_article(this.zimFilename, path);
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  .zim-search {
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    padding: 16px;
+  }
+
+</style>

--- a/kolibri_zim_plugin/root_urls.py
+++ b/kolibri_zim_plugin/root_urls.py
@@ -2,6 +2,7 @@ from kolibri.dist.django.conf.urls import url
 
 from .views import ZimArticleView
 from .views import ZimIndexView
+from .views import ZimSearchView
 
 urlpatterns = [
     url(
@@ -13,5 +14,10 @@ urlpatterns = [
         r"^zim/content/(?P<zim_filename>[^/]+.zim)/(?P<zim_article_path>.+)$",
         ZimArticleView.as_view(),
         name="zim_article",
+    ),
+    url(
+        r"^zim/search/(?P<zim_filename>[^/]+.zim)$",
+        ZimSearchView.as_view(),
+        name="zim_search",
     ),
 ]

--- a/kolibri_zim_plugin/root_urls.py
+++ b/kolibri_zim_plugin/root_urls.py
@@ -1,13 +1,17 @@
 from kolibri.dist.django.conf.urls import url
 
-from .views import zim_article
-from .views import zim_index
+from .views import ZimArticleView
+from .views import ZimIndexView
 
 urlpatterns = [
-    url(r"^zimcontent/(?P<zim_filename>[^/]+.zim)$", zim_index, name="zim_index"),
     url(
-        r"^zimcontent/(?P<zim_filename>[^/]+.zim)/(?P<zim_article_path>.+)$",
-        zim_article,
+        r"^zim/content/(?P<zim_filename>[^/]+.zim)$",
+        ZimIndexView.as_view(),
+        name="zim_index",
+    ),
+    url(
+        r"^zim/content/(?P<zim_filename>[^/]+.zim)/(?P<zim_article_path>.+)$",
+        ZimArticleView.as_view(),
         name="zim_article",
     ),
 ]

--- a/kolibri_zim_plugin/views.py
+++ b/kolibri_zim_plugin/views.py
@@ -132,6 +132,7 @@ class ZimSearchView(_ZimFileViewMixin, View):
 
     def get(self, request, zim_filename):
         query = request.GET.get("query")
+        start = request.GET.get("start", 0)
         max_results = request.GET.get("max_results", 30)
         suggest = "suggest" in request.GET
 
@@ -147,13 +148,15 @@ class ZimSearchView(_ZimFileViewMixin, View):
             return HttpResponseBadRequest('Invalid "max_results"')
 
         if suggest:
-            search = self.zim_file.suggest(query, start=0, end=max_results)
+            count = self.zim_file.get_suggestions_results_count(query)
+            search = self.zim_file.suggest(query, start=start, end=start + max_results)
         else:
-            search = self.zim_file.search(query, start=0, end=max_results)
+            count = self.zim_file.get_search_results_count(query)
+            search = self.zim_file.search(query, start=start, end=start + max_results)
 
         articles = list(self.__article_metadata(path) for path in search)
 
-        return JsonResponse({"articles": articles, "count": len(articles)})
+        return JsonResponse({"articles": articles, "count": count})
 
     def __article_metadata(self, zim_article_path):
         zim_article = self.zim_file.get_article(zim_article_path)

--- a/kolibri_zim_plugin/views.py
+++ b/kolibri_zim_plugin/views.py
@@ -132,12 +132,17 @@ class ZimSearchView(_ZimFileViewMixin, View):
 
     def get(self, request, zim_filename):
         query = request.GET.get("query")
+        suggest = "suggest" in request.GET
         start = request.GET.get("start", 0)
         max_results = request.GET.get("max_results", 30)
-        suggest = "suggest" in request.GET
 
         if not query:
             return HttpResponseBadRequest('Missing "query"')
+
+        try:
+            start = int(start)
+        except ValueError:
+            return HttpResponseBadRequest('Invalid "start"')
 
         try:
             max_results = int(max_results)

--- a/kolibri_zim_plugin/views.py
+++ b/kolibri_zim_plugin/views.py
@@ -151,9 +151,9 @@ class ZimSearchView(_ZimFileViewMixin, View):
         else:
             search = self.zim_file.search(query, start=0, end=max_results)
 
-        results = list(self.__article_metadata(path) for path in search)
+        articles = list(self.__article_metadata(path) for path in search)
 
-        return JsonResponse({"results": results, "count": len(results)})
+        return JsonResponse({"articles": articles, "count": len(articles)})
 
     def __article_metadata(self, zim_article_path):
         zim_article = self.zim_file.get_article(zim_article_path)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,10 @@ setup(
         str(plugin_name),  # https://github.com/pypa/setuptools/pull/597
     ],
     package_dir={plugin_name: plugin_name},
-    install_requires=["libzim==0.0.3.post0"],
+    install_requires=[
+        "beautifulsoup4==4.9.3",
+        "libzim==0.0.3.post0",
+    ],
     include_package_data=True,
     license="MIT",
     zip_safe=False,


### PR DESCRIPTION
This change adds search functionality to the ZIM file renderer, including content snippets (with one more dependency: beautifulsoup4), and basic pagination.

![Screenshot from 2021-06-11 17-12-01](https://user-images.githubusercontent.com/132063/121758927-50117480-cad8-11eb-95a4-9542c91b9b87.png)

It is a bit strange that searching for "Potato" doesn't return the article titled "Potato" as its first result, but I think that's more of a problem with libzim, unfortunately. We can create a new ticket for it if it turns out to be an issue for the zim files we are using in Endless Key.

https://phabricator.endlessm.com/T32033