### PR TITLE
ZimSearchView: Add search suggestions

### DIFF
--- a/kolibri_zim_plugin/assets/src/views/ZimSearchForm.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimSearchForm.vue
@@ -21,6 +21,7 @@
         name="search-input"
         class="search-input"
         dir="auto"
+        autocomplete="off"
         :placeholder="$tr('searchPlaceholder')"
       >
       <div class="search-buttons-wrapper">
@@ -90,6 +91,11 @@
         return this.searchInputValue === this.lastSubmitValue;
       },
     },
+    watch: {
+      searchInputValue(value) {
+        this.$emit('input', value);
+      },
+    },
     mounted() {},
     beforeDestroy() {},
     methods: {
@@ -98,6 +104,12 @@
        */
       focus() {
         this.$refs.searchInput.focus();
+      },
+      /**
+       * @public
+       */
+      getInput() {
+        return this.searchInputValue;
       },
       onEscKeyDown() {
         if (this.searchInputValue === '') {


### PR DESCRIPTION
This adds a list of search suggestions to the search interface. The suggestions appear as the user types in the search box, and they remain above the usual search results after submitting the form. (This is because the suggestions are often quite different from the full text search results, so it makes sense for them to be easy to access).

![Screenshot from 2021-06-14 16-12-42](https://user-images.githubusercontent.com/132063/121970433-63684e00-cd2b-11eb-8b57-97d7e75616ff.png)

https://phabricator.endlessm.com/T32128