### PR TITLE
ZimContentView: Use shadow dom instead of an iframe

### DIFF
--- a/kolibri_zim_plugin/assets/src/module.js
+++ b/kolibri_zim_plugin/assets/src/module.js
@@ -1,9 +1,19 @@
+import store from 'kolibri.coreVue.vuex.store';
 import ContentRendererModule from 'content_renderer_module';
 import ZimComponent from './views/ZimRendererIndex';
+import storeModule from './modules';
 
 class ZimModule extends ContentRendererModule {
   get rendererComponent() {
     return ZimComponent;
+  }
+
+  get store() {
+    return store;
+  }
+
+  ready() {
+    this.store.registerModule('zim', storeModule);
   }
 }
 

--- a/kolibri_zim_plugin/assets/src/modules/index.js
+++ b/kolibri_zim_plugin/assets/src/modules/index.js
@@ -1,0 +1,33 @@
+const DEFAULT_NAVIGATION_HISTORY = [
+  {
+    path: '',
+    title: '',
+  },
+];
+
+export default {
+  namespaced: true,
+  state: {
+    navigationHistory: DEFAULT_NAVIGATION_HISTORY.slice(),
+  },
+  mutations: {
+    SET_NAVIGATION_HISTORY(state, navigationHistory) {
+      state.navigationHistory = navigationHistory;
+    },
+  },
+  getters: {},
+  actions: {
+    pushNavigationHistory(store, { path, title }) {
+      const navigationHistory = store.state.navigationHistory.slice();
+      const existingIndex = navigationHistory.findIndex(entry => entry.path === path);
+      if (existingIndex >= 0) {
+        navigationHistory.splice(existingIndex);
+      }
+      navigationHistory.push({ path, title });
+      store.commit('SET_NAVIGATION_HISTORY', navigationHistory);
+    },
+    resetNavigationHistory(store) {
+      store.commit('SET_NAVIGATION_HISTORY', DEFAULT_NAVIGATION_HISTORY.slice());
+    },
+  },
+};

--- a/kolibri_zim_plugin/assets/src/views/ZimBreadcrumbsMenu.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimBreadcrumbsMenu.vue
@@ -11,8 +11,8 @@
           class="zim-breadcrumb-button"
           :primary="false"
           appearance="flat-button"
-          :text="breadcrumb.title"
-          :title="breadcrumb.title"
+          :text="breadcrumbTitle(breadcrumb)"
+          :title="breadcrumbTitle(breadcrumb)"
           :disabled="!breadcrumbIsEnabled(breadcrumb)"
           @click="$emit('activate', breadcrumb)"
         />
@@ -25,32 +25,47 @@
 
 <script>
 
+  import { mapState } from 'vuex';
+
   export default {
     name: 'ZimBreadcrumbsMenu',
     components: {},
     props: {
-      breadcrumbs: {
-        type: Array,
-      },
-      currentUrl: {
-        type: String,
+      currentPathIsEnabled: {
+        type: Boolean,
       },
     },
     computed: {
+      ...mapState('zim', ['navigationHistory']),
+      currentPath() {
+        return this.$route.query.zimPath || '';
+      },
+      breadcrumbs() {
+        return this.navigationHistory.slice();
+      },
       visibleBreadcrumbs() {
         return this.breadcrumbs.slice(-4);
       },
     },
     methods: {
       breadcrumbIsEnabled(breadcrumb) {
-        if (breadcrumb.href === undefined) {
-          return false;
+        if (breadcrumb.path === this.currentPath) {
+          return this.currentPathIsEnabled;
         } else {
-          return breadcrumb.href !== this.currentUrl;
+          return true;
+        }
+      },
+      breadcrumbTitle(breadcrumb) {
+        if (breadcrumb.path === '') {
+          return this.$tr('homeBreadcrumb');
+        } else {
+          return breadcrumb.title;
         }
       },
     },
-    $trs: {},
+    $trs: {
+      homeBreadcrumb: 'Home',
+    },
   };
 
 </script>

--- a/kolibri_zim_plugin/assets/src/views/ZimContentView.vue
+++ b/kolibri_zim_plugin/assets/src/views/ZimContentView.vue
@@ -30,6 +30,14 @@
         return this.$route.query.zimPath || '';
       },
     },
+    watch: {
+      '$route.query.zimPath': {
+        handler: function(zimPath) {
+          this.loadArticle(zimPath);
+        },
+        immediate: true,
+      },
+    },
     mounted() {
       this.shadow = this.$refs.content.attachShadow({ mode: 'closed' });
       this.shadow.addEventListener('click', this.onShadowClick, { capture: true });


### PR DESCRIPTION
This change gives us more control over the Zim content being rendered, such as being able to track navigation events reliably and open external URLs in a new window. It also means the URL reflects the article being shown, which enables bookmarking and linking from other places in Kolibri (such as in search results).

There is one issue where the ZimRendererIndex component is re-rendered whenever the URL changes. This happens because we're adding a Zim path to the URL in a way that the rest of Kolibri doesn't know about. Still,  other than a bunch of components disappearing and reappearing, the state is just fine since it is being managed properly now.

If we eventually move this plugin into core Kolibri, we would need a bunch of unpleasant polyfills for compatibility with IE11, but that's a problem for another day.

https://phabricator.endlessm.com/T33078